### PR TITLE
bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "locomotive",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Powerful MVC web framework for Node.js.",
   "keywords": [
     "express",


### PR DESCRIPTION
installing this repo and then installing upstream locomotive will cause npm to install this repo because it's cache.

It requires a `npm cache clean` to install locomotive upstream.
